### PR TITLE
Fix missing pull-down on OBS Pro and remove double button pin initial…

### DIFF
--- a/src/OpenBikeSensorFirmware.cpp
+++ b/src/OpenBikeSensorFirmware.cpp
@@ -237,7 +237,6 @@ void setup() {
   // Configure button pin as INPUT
   //##############################################################
 
-  pinMode(PUSHBUTTON_PIN, INPUT);
   pinMode(IP5306_BUTTON, OUTPUT);
   digitalWrite(IP5306_BUTTON, LOW);
   pinMode(BatterieVoltage_PIN, INPUT);

--- a/src/utils/button.cpp
+++ b/src/utils/button.cpp
@@ -26,7 +26,7 @@
 #include "variant.h"
 
 Button::Button(int pin) : mPin(pin) {
-  pinMode(pin, INPUT);
+  pinMode(pin, INPUT_PULLDOWN);
   mLastStateChangeMillis = mLastRawReadMillis = millis();
   mLastState = mLastRawState = read();
 }


### PR DESCRIPTION
We forgot to add a pull-down resistor on the current OBS Pro prototypes. This patch enables the internal pull-down, which fixed this. This should not affect the classic, as it also uses an (external) pull-down. The internal is much weaker (42k) than the external (10k).
This fixes the long delay of button presses and probably other problems related to the button and flashing (as the button uses a strapping-pin).
I also removed a double-initialization of the button pin.